### PR TITLE
Add "pipeline" and "-defer" to reduce the time of waiting for server response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
   apt:
     packages:
       - tcl
-      - tcllib
 
 cache:
   - apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: java
+language: generic
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ using the tclsh in your path to check the output of 'info library' command.
 The method of detection should be expanded in the future to play more nicely
 with alternate tcl installations.
 
-## Usage
+## Basic Usage
 
 'package require redis' will get you started.
 
@@ -32,10 +32,27 @@ you!):
     $redis get abc
 ```
 
-## Defer and Collect
+## Pipeline, Defer and Collect
 
 There is chance that you want to send redis commands in pipeline mode, and read
 all the result back in a batch.
+
+So we have the `$redis pipeline` command for this.
+
+```tcl
+    $redis pipeline {
+        $redis set abc 321
+        $redis -key abc get abc
+
+        $redis set def 789
+        $redis -key def -- get def
+    }
+```
+
+One problem here is when complex logic are inserted between each redis command.
+The brace will be very large. And it's not good for clear reading.
+
+We noticed that the key here is defer reading of the results. So we introce `-defer` for it. 
 
 ```tcl
     $redis -defer set abc 123
@@ -50,6 +67,12 @@ all the result back in a batch.
 
     # Output: 0 OK abc 123 2 OK def 456
 ```
+
+  * Use `-defer` option to send commands to redis server first.
+  * But defer the reasult reading to later stage.
+  * Use `$redis collect` to get all the results back.
+  * Option `-key` is used to provide the key in the returned `dict`
+  * When `-key` option is missing, a sequence number is used.
 
 ## PUB/SUB
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ using the tclsh in your path to check the output of 'info library' command.
 The method of detection should be expanded in the future to play more nicely
 with alternate tcl installations.
 
-Usage:
+## Usage
 
 'package require redis' will get you started.
 
@@ -22,32 +22,63 @@ redis commands.  For example, the following creates a redis connection, and
 runs the redis time command (it ignores the output however, that part is up to
 you!):
 
+```tcl
     package require redis
-    set r [redis $host $port]
-    $r time
+    
+    set redis [redis $host $port]
+    
+    $redis time
+    $redis set abc 123
+    $redis get abc
+```
 
+## Defer and Collect
+
+There is chance that you want to send redis commands in pipeline mode, and read
+all the result back in a batch.
+
+```tcl
+    $redis -defer set abc 123
+    $redis -defer -key abc get abc
+    
+    # use "--" to separate redis command. This make code easy to read.
+    
+    $redis -defer -- set def 456
+    $redis -defer -key def -- get def
+    
+    set result [$redis collect]
+
+    # Output: 0 OK abc 123 2 OK def 456
+```
+
+## PUB/SUB
 
 It is possible to use this client for basic pub/sub operations with redis.  To
-subscribe to a channel you must first set a callback through the following:
+subscribe to a channel you must first set a callback and then subscribe as below:
 
-    $r setcallback procname
+```tcl
+    $redis setcallback procname
 
-After the callback is set channels can be subscribed to as:
-
-    $r subscribe x y taters
+    $redis subscribe x y taters
+```
 
 Once a specific connection is set for a subscription it CANNOT be used for
 other redis communications.  At this time it is only possible to bulk
 unsubscribe from all channels through:
 
-    $r unsubscribe
+```tcl
+    $redis unsubscribe
+```
 
 This will also reset callback to empty. To get the callback before unsubscribe:
 
-    set callback [$r getcallback]
+```tcl
+    set callback [$redis getcallback]
+```
 
 An example of callback may looks like:
 
+```tcl
     proc onPublish {channels redis type reply} {
       if {[llength $reply]==1 && $reply>0} {
         # OK subscribe $reply
@@ -57,3 +88,6 @@ An example of callback may looks like:
       lassign $reply kind channel data
       # kind = enum { subscribe unsubscribe message }
     }
+ ```
+ 
+ 

--- a/src/redis.tcl
+++ b/src/redis.tcl
@@ -18,7 +18,7 @@
 #         $r ping [list handlePong]
 #     }
 # }
-# 
+#
 # set r [redis]
 # $r blocking 0
 # $r get fo [list handlePong]
@@ -45,26 +45,57 @@ proc redis {{server 127.0.0.1} {port 6379} {defer 0}} {
     if {[catch {set fd [socket $server $port]} error_msg]} {
         error "REDIS: $error_msg"
     }
-    
+
     fconfigure $fd -translation binary
     set id [incr ::redis::id]
     set ::redis::fd($id) $fd
     set ::redis::blocking($id) 1
     set ::redis::subscribed($id) 0
     set ::redis::deferred($id) $defer
+    set ::redis::pipeline($id) ""
     ::redis::redis_reset_state $id
     interp alias {} ::redis::redisHandle$id {} ::redis::__dispatch__ $id
 }
 
-proc ::redis::__dispatch__ {id method args} {
+proc ::redis::__dispatch__ {id args} {
     set fd $::redis::fd($id)
     set blocking $::redis::blocking($id)
     set deferred $::redis::deferred($id)
     set subscribed $::redis::subscribed($id)
+
+    set method ""
+
+    set argidx  0 ; set argskip 0
+    foreach arg $args {
+        incr argidx ; if {$argskip>0} { incr argskip -1 ; continue }
+
+        switch -glob -- $arg {
+            "-defer" {
+                set deferred 1
+                set deferred_key [dict size $::redis::pipeline($id)]
+                continue
+            }
+            "-key" {
+                set deferred_key [lindex $args $argidx] ; incr argskip
+                continue
+            }
+            "--" {
+                set method [lindex $args $argidx]
+                set args [lrange $args $argidx+1 end]
+                break
+            }
+            default {
+                set method $arg
+                set args [lrange $args $argidx end]
+                break
+            }
+        }
+    }
+
     if {$subscribed} {
         if { $method ne "subscribe" && $method ne "close" && $method ne "setcallback" && $method ne "unsubscribe" } {
             error "This channel can only be used for pub/sub purposes after subscription"
-        }  
+        }
     }
     if {[info command ::redis::__method__$method] eq {}} {
         if {$blocking == 0} {
@@ -73,7 +104,12 @@ proc ::redis::__dispatch__ {id method args} {
             }
             set callback [lindex $args end]
             set args [lrange $args 0 end-1]
+        } else {
+            if { $deferred } {
+              dict set ::redis::pipeline($id) $deferred_key ""
+            }
         }
+
         ::redis::redis_write $fd [::redis::redis_format_message $method {*}$args]
         flush $fd
 
@@ -105,6 +141,7 @@ proc ::redis::redis_format_message {method args } {
 proc ::redis::__method__setcallback {id fd callback} {
     set ::redis::callback($id) [list $callback]
 }
+
 proc ::redis::__method__getcallback {id fd} {
     return $::redis::callback($id)
 }
@@ -174,6 +211,18 @@ proc ::redis::__method__close {id fd} {
 
 proc ::redis::__method__channel {id fd} {
     return $fd
+}
+
+proc ::redis::__method__collect {id fd} {
+    set result [dict create]
+
+    dict for {key value} $::redis::pipeline($id) {
+      set value [::redis::redis_read_reply $fd]
+      dict set result $key $value
+    }
+    set ::redis::pipeline($id) ""
+
+    return $result
 }
 
 proc ::redis::redis_write {fd buf} {
@@ -309,3 +358,5 @@ proc ::redis::redis_readable {fd id} {
         }
     }
 }
+
+# vim:set syntax=tcl sw=4: #

--- a/test/pipeline.test
+++ b/test/pipeline.test
@@ -1,0 +1,37 @@
+#!/usr/bin/env tclsh
+
+package require tcltest
+
+source $::env(REDISTCL)
+
+namespace eval redis::test {
+  namespace import ::tcltest::test
+
+  ::tcltest::configure -verbose pass
+
+  test redis-defer {defer redis result collect} -setup {
+    set redis [redis]
+  } -body {
+    $redis -defer set abc 123
+    $redis -defer -key abc get abc
+
+    $redis -defer -- set def 456
+    $redis -defer -key def -- get def
+
+    $redis collect
+  } -result {0 OK abc 123 2 OK def 456}
+
+  test redis-pipeline {pipeline redis commands} -setup {
+    set redis [redis]
+  } -body {
+    $redis pipeline {
+      $redis set abc 321
+      $redis -key abc get abc
+
+      $redis set def 789
+      $redis -key def -- get def
+    }
+  } -result {0 OK abc 321 2 OK def 789}
+}
+
+::tcltest::cleanupTests

--- a/test/redis-server.test
+++ b/test/redis-server.test
@@ -1,0 +1,15 @@
+#!/usr/bin/env tclsh
+
+package require tcltest
+
+source $::env(REDISTCL)
+
+namespace eval redis::test {
+  namespace import ::tcltest::test
+
+  test redis-set-get {Test simple set and get} -body {
+    set r [redis]
+    $r set abc 123
+    $r get abc
+  } -result 123
+}

--- a/test/redis-server.test
+++ b/test/redis-server.test
@@ -7,9 +7,13 @@ source $::env(REDISTCL)
 namespace eval redis::test {
   namespace import ::tcltest::test
 
+  ::tcltest::configure -verbose pass
+
   test redis-set-get {Test simple set and get} -body {
     set r [redis]
     $r set abc 123
     $r get abc
   } -result 123
 }
+
+::tcltest::cleanupTests

--- a/test/testsuite.tcl
+++ b/test/testsuite.tcl
@@ -1,5 +1,5 @@
 #!/usr/bin/env tclsh
-package require Tcl 
+package require Tcl
 package require tcltest
 ::tcltest::configure -testdir \
         [file dirname [file normalize [info script]]]


### PR DESCRIPTION
See "Pipeline, defer and collect" part of the README.md

Basically, "$redis pipeline" command is introduced to send a batch of redis commands out and reading back the result in a batch.

To allow mixing complex logic between each redis command, "-defer" options is introduced to delay the result reading.

This two new feature can help reduce the time of waiting for server response.
